### PR TITLE
Allow 'service_account_key' to contain either the path to or the content of a key file

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,6 @@ provider "gdrive" {
 - **retry_on** (List of Number) A list of HTTP error codes you want the provider to retry on (e.g. 404).
 - **service_account** (String) The email address of the Service Account you want to impersonate with Application Default Credentials (ADC).
 Leave empty if you want to use the Service Account of a GCE instance directly.
-- **service_account_key** (String) The path to a key file for your Service Account.
+- **service_account_key** (String) The path to or the content of a key file for your Service Account.
 Leave empty if you want to use Application Default Credentials (ADC).
 - **subject** (String) The email address of the Workspace user you want to impersonate with Domain Wide Delegation (DWD)

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package provider
 
 import (
+	"encoding/json"
 	"io"
 	"os"
 
@@ -79,8 +80,15 @@ Leave empty if you want to use the Service Account of a GCE instance directly.`,
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	serviceAccountKey := d.Get("service_account_key").(string)
 	if serviceAccountKey != "" {
-		saKey := []byte(serviceAccountKey)
-		if f, err := os.Open(serviceAccountKey); err == nil {
+		var saKey []byte
+		s := []byte(serviceAccountKey)
+		if json.Valid(s) {
+			saKey = s
+		} else {
+			f, err := os.Open(serviceAccountKey)
+			if err != nil {
+				return nil, err
+			}
 			saKey, err = io.ReadAll(f)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
This change makes this provider behave like the Google Workspace provider by accepting either a filename or JSON content to authenticate the service account. It's a non-breaking change.